### PR TITLE
Fix installer redirects under NO_CLOBBER

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -296,10 +296,10 @@ System::install_package() {
 
     # Background execution for spinner compatibility
     case "${SYSTEM_INFO[PKG_MANAGER]}" in
-        pacman) sudo pacman -S --noconfirm "$pkg" &>/dev/null & ;;
-        brew)   brew install "$pkg" &>/dev/null & ;;
-        apt)    sudo apt-get install -y "$pkg" &>/dev/null & ;;
-        dnf)    sudo dnf install -y "$pkg" &>/dev/null & ;;
+        pacman) sudo pacman -S --noconfirm "$pkg" >| /dev/null 2>&1 & ;;
+        brew)   brew install "$pkg" >| /dev/null 2>&1 & ;;
+        apt)    sudo apt-get install -y "$pkg" >| /dev/null 2>&1 & ;;
+        dnf)    sudo dnf install -y "$pkg" >| /dev/null 2>&1 & ;;
     esac
 }
 


### PR DESCRIPTION
## Problem

The installer enables `setopt NO_CLOBBER` and uses `&>/dev/null` for package installs. With `NO_CLOBBER`, redirecting to existing `/dev/null` fails, so every "y" install fails immediately.

## Fix

Use `>| /dev/null 2>&1` to force clobber for those redirects, keeping output suppressed while remaining compatible with `NO_CLOBBER`.

## Notes

No automated tests (interactive installer).
