### PR TITLE
Guard dependency installs when Homebrew is missing

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -394,6 +394,12 @@ Installer::check_dependencies() {
     Logger::info "Analyzing Dependencies..."
     sleep 2
 
+    if [[ "${SYSTEM_INFO[PKG_MANAGER]}" == "brew" ]] && ! (( $+commands[brew] )); then
+        Logger::error "Homebrew not found. Install it from https://brew.sh and re-run."
+        Logger::warn "Skipping dependency installation."
+        return
+    fi
+
     local missing_pkgs=()
     local installed_pkgs=()
 


### PR DESCRIPTION
## Problem

On macOS, the script assumes Homebrew exists. If it doesn’t, every “y” install fails and can abort the installer.

## Fix

Detect missing Homebrew up front, report a clear error with the official install link, and skip dependency installs rather than attempting them.

## Notes

No automated tests (interactive installer).
