### PR TITLE
Handle install failures without aborting

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -417,7 +417,10 @@ Installer::check_dependencies() {
 
             # Show spinner while waiting for PID ($!)
             Interface::spinner $! "Installing ${package}..."
-            wait $!
+            if ! wait $!; then
+                Logger::error "Failed to install $package"
+                continue
+            fi
 
             if (( $+commands[$package] )); then
                 Logger::success "Installed $package"
@@ -435,8 +438,11 @@ Installer::ensure_zsh_shell() {
     if ! (( $+commands[zsh] )); then
         if Interface::prompt_confirm "Zsh is not installed. Install it?"; then
             System::install_package "zsh"
-            wait $!
-            Logger::success "Zsh installed!"
+            if ! wait $!; then
+                Logger::error "Failed to install zsh"
+            else
+                Logger::success "Zsh installed!"
+            fi
         else
             Logger::warn "Skipping Zsh installation. Script may fail."
         fi


### PR DESCRIPTION
## Problem

With `setopt ERR_EXIT`, any non‑zero `wait $!` exits the entire script. A single package install failure or a failed Zsh install aborts the installer before it can report status cleanly.

## Fix

Wrap `wait $!` in a guarded check and handle failures explicitly, allowing the installer to continue and surface the error properly.

## Notes

No automated tests (interactive installer).
