### PR TITLE
Migrate PATH exports into User-Overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ For custom aliases, functions, or exports that you don't want tracked by git (or
 
 - **File**: `~/User-Overrides.zsh`
 - **Usage**: Automatically sourced at the end of `.zshrc`.
+  - During installation, any `PATH` exports found in your existing `~/.zshrc` are copied into this file (once), so your custom paths are preserved.
 
 ### 3. Secrets (API Keys)
 

--- a/install.zsh
+++ b/install.zsh
@@ -456,6 +456,39 @@ Installer::ensure_zsh_shell() {
     fi
 }
 
+Installer::migrate_user_path() {
+    local source_rc="$HOME/.zshrc"
+    local override_file="$HOME/User-Overrides.zsh"
+    local marker_begin="# >>> zsh-conf: migrated PATH from ~/.zshrc >>>"
+    local marker_end="# <<< zsh-conf: migrated PATH from ~/.zshrc <<<"
+
+    [[ -f "$source_rc" ]] || return
+    [[ "$source_rc:A" != "${CONFIG_PATHS[RC]:A}" ]] || return
+
+    if [[ -f "$override_file" ]] && grep -qF "$marker_begin" "$override_file"; then
+        return
+    fi
+
+    local path_lines
+    path_lines="$(awk '{
+        if ($0 ~ /^[[:space:]]*export[[:space:]]+PATH=/) {print; next}
+        if ($0 ~ /^[[:space:]]*PATH=.*export[[:space:]]+PATH/) {print; next}
+    }' "$source_rc")"
+
+    [[ -n "$path_lines" ]] || return
+
+    {
+        print ""
+        print "$marker_begin"
+        print "# Source: $source_rc"
+        print "# Added on: $(date +%Y-%m-%d)"
+        print "$path_lines"
+        print "$marker_end"
+    } >> "$override_file"
+
+    Logger::success "Migrated PATH exports to $override_file"
+}
+
 Installer::configure_user_features() {
     Interface::print_banner
     Logger::info "Feature Configuration"
@@ -538,6 +571,9 @@ Installer::main() {
     FileSystem::atomic_backup "${CONFIG_PATHS[ENV]}"
     FileSystem::atomic_backup "${CONFIG_PATHS[CONF]}"
     mkdir -p "${CONFIG_PATHS[CACHE]}" 2>/dev/null
+
+    # 5b. Migrate PATH exports from existing local .zshrc (if any)
+    Installer::migrate_user_path
 
     # 6. Repository Cloning
     Interface::print_banner


### PR DESCRIPTION
## Summary

During setup, copy any `PATH` exports from an existing `~/.zshrc` into `~/User-Overrides.zsh` (once) so custom paths are preserved when switching to the new config. Also document this behavior in the README.

## Details

- Extracts `export PATH=...` and `PATH=...; export PATH` lines.
- Adds a marked block to `~/User-Overrides.zsh` to avoid duplicate migrations.
- Skips if `~/.zshrc` doesn’t exist or is already the new config file.

## Notes

No automated tests (interactive installer).
